### PR TITLE
Fix issue with running on python 2.6

### DIFF
--- a/superzippy/bootstrapper/zipsite.py
+++ b/superzippy/bootstrapper/zipsite.py
@@ -20,6 +20,8 @@ from __future__ import print_function
 import site as _site
 from site import *
 
+
+from contextlib import closing
 import zipfile
 import os
 import traceback
@@ -112,7 +114,7 @@ def exists(path):
         return os.path.exists(path)
 
     # otherwise check the zip file.
-    with zipfile.ZipFile(archive_path, mode = "r") as archive:
+    with closing(zipfile.ZipFile(archive_path, mode = "r")) as archive:
         try:
             archive.getinfo(file_path)
         except KeyError:
@@ -145,7 +147,7 @@ def addsitedir(sitedir, known_paths = None, prepend_mode = False):
     else:
         sys.path.append(sitedir)
 
-    with zipfile.ZipFile(archive_path, mode = "r") as archive:
+    with closing(zipfile.ZipFile(archive_path, mode = "r")) as archive:
         # Go trhough everything in the archive...
         for i in archive.infolist():
             # and grab all the .pth files.


### PR DESCRIPTION
I'm on python 2.6 (CentOS6) and the resulting executable fails to run with this error..

``` pytb
Traceback (most recent call last):
  File "/usr/lib/python2.6/runpy.py", line 122, in _run_module_as_main
    "__main__", fname, loader, pkg_name)
  File "/usr/lib/python2.6/runpy.py", line 34, in _run_code
    exec code in run_globals
  File "./devtool.sz/__main__.py", line 30, in <module>
  File "./devtool.sz/zipsite.py", line 148, in addsitedir
AttributeError: ZipFile instance has no attribute '__exit__'
```

...because the ability to use a ZipFile as a context-manager wasn't added until 2.7 according to http://docs.python.org/2/library/zipfile.html#zipfile-objects

This change fixed it for me..
